### PR TITLE
Fix H2 color in flipcard

### DIFF
--- a/blocks/flipcard/flipcard.css
+++ b/blocks/flipcard/flipcard.css
@@ -57,10 +57,12 @@
 
 .flip-card-back p {
   font-size: 16px;
+  color: white;
 }
 
 .flip-card-back h2 {
   font-size: 20px;
+  color: white;
 }
 
 .flip-card:hover .flip-card-inner {


### PR DESCRIPTION
Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.page/drafts/silviu/flipcard
- After: https://flipcardfix--learninga-z--aemsites.hlx.page/drafts/silviu/flipcard


Fix H2 color from blue to white on the back of the flipcard.
This had appeared after https://github.com/aemsites/learninga-z/pull/76 was merged