### PR TITLE
related breakroom list from links

### DIFF
--- a/blocks/related-posts/related-posts.css
+++ b/blocks/related-posts/related-posts.css
@@ -1,0 +1,19 @@
+.related-posts {
+    .posts-list {
+        padding-top: 15px;
+        margin-bottom: 10px;
+        border-bottom: 1px solid #cbcbcb;
+
+        &:last-child {
+            border-bottom: none;
+        }
+
+        h3 {
+            font-size: 18px;
+            font-weight: bold;
+            line-height: 1.45;
+            margin-bottom: 1em;
+            font-family: var(--body-font-family);
+        }
+    }
+}

--- a/blocks/related-posts/related-posts.js
+++ b/blocks/related-posts/related-posts.js
@@ -1,0 +1,28 @@
+import { createTag, lookupBlogs } from '../../scripts/scripts.js';
+
+export async function createPageLinks(row, style) {
+  const linkPost = document.createElement('div');
+  if (style) linkPost.classList.add(style);
+  const title = createTag('div', { class: 'title' });
+  title.innerHTML = `<a href="${row.path}"><h3>${row.title}</h3></a>`;
+  linkPost.append(title);
+  return linkPost;
+}
+
+export default async function decorate(block) {
+  const pathNames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
+  block.textContent = '';
+  // Make a call to the blog index and get the json for just the pathNames the author has put in
+  const pageList = await lookupBlogs(pathNames);
+  const titlesList = createTag('div', { class: 'titles-list' });
+
+  block.append(titlesList);
+  if (pageList.length) {
+    pageList.forEach(async (row) => {
+      block.append(await createPageLinks(row, 'posts-list'));
+    });
+    block.innerHTML = '<h2 class="related-title">Related Breakroom Posts</h2>';
+  } else {
+    block.remove();
+  }
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -255,7 +255,6 @@ export async function lookupBlogs(pathNames) {
   return (result);
 }
 
-
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -230,6 +230,32 @@ async function loadTemplate() {
   return undefined;
 }
 
+/* Card related stuff */
+
+/**
+ * Gets details about blog pages that are indexed
+ * @param {Array} pathNames list of pathNames
+ */
+
+export async function lookupBlogs(pathNames) {
+  if (!window.blogIndex) {
+    const resp = await fetch(`${window.hlx.codeBasePath}/site/resources/breakroom-blog/query-index.json`);
+    const json = await resp.json();
+    const lookup = {};
+    json.data.forEach((row) => {
+      lookup[row.path] = row;
+      if (row.image || row.image.startsWith('/default-meta-image.png')) row.image = `/${window.hlx.codeBasePath}${row.image}`;
+    });
+    window.blogIndex = {
+      data: json.data,
+      lookup,
+    };
+  }
+  const result = pathNames.map((path) => window.blogIndex.lookup[path]).filter((e) => e);
+  return (result);
+}
+
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -403,7 +403,6 @@ a:hover {
     line-height: 1.2;
   }
 
-
   h2 {
     font-size: var(--body-font-size-m);
     margin-bottom: 1em;
@@ -439,7 +438,8 @@ nav li {
   text-transform: uppercase;
 }
 
-/* themes - TBD if we use product names for these or not */
+/* end default theme */
+
 [data-theme="purple"] {
   background-color: var(--purple);
   color: var(--white);
@@ -471,6 +471,16 @@ nav li {
       color: var(--white);
     }
   }
+
+body.red {
+  .breadcrumbs-outer {
+    background-color: var(--red);
+  }
+
+  .related-posts :is(h3, a, a:hover) {
+    color: var(--red);
+  }
+}
 
 [data-theme="red"] {
   .button.primary {


### PR DESCRIPTION
Sidebar list of blog titles, only looks at the breakroom-blog/query-index.

Fix #116

Test URLs:
Theme is red
- Before: https://main--learninga-z--aemsites.hlx.page/drafts/chelms/research-and-efficacy/mcrel-study-razplus
- After: https://116-relatedposts--learninga-z--aemsites.hlx.page/drafts/chelms/research-and-efficacy/mcrel-study-razplus

No theme defined
- Before: https://main--learninga-z--aemsites.hlx.page/drafts/chelms/research-and-efficacy/copy-of-english-language-learning-english
- After: https://116-relatedposts--learninga-z--aemsites.hlx.page/drafts/chelms/research-and-efficacy/copy-of-english-language-learning-english

Testing criteria - what should the reviewer look for in your PR:
- Compare the style of the block with what you see at https://www.learninga-z.com/site/resources/breakroom-blog/value-of-teacher-grant-program
- If a link is authored which is not in the breakroom-blog/query-index, then no link is shown

