### PR TITLE
Breadcumb set invalid URLs to null and continue

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -298,7 +298,7 @@ export async function lookupBlogs(pathNames) {
 /* BREADCRUMBS START */
 
 const getPageTitle = async (url) => {
-  const resp = await fetch(url);
+  const resp = await fetch(url); // invalid URL will return 404 in console
   if (resp.ok) {
     const html = document.createElement('div');
     html.innerHTML = await resp.text();
@@ -314,13 +314,11 @@ const getAllPathsExceptCurrent = async (paths) => {
   for (let i = 0; i < pathsList.length - 1; i += 1) {
     const pathPart = pathsList[i];
     const prevPath = result[i - 1] ? result[i - 1].path : '';
-    if (pathPart !== 'authors') { // exclude authors b/c there's no page there
-      const path = `${prevPath}/${pathPart}`;
-      const url = `${window.location.origin}${path}`;
-      /* eslint-disable-next-line no-await-in-loop */
-      const name = await getPageTitle(url);
-      result.push({ path, name, url });
-    }
+    const path = `${prevPath}/${pathPart}`;
+    const url = `${window.location.origin}${path}`;
+    /* eslint-disable-next-line no-await-in-loop */
+    const name = await getPageTitle(url);
+    result.push({ path, name, url });
   }
   return result.filter(Boolean).slice(1); // remove first element ('site') from the array
 };


### PR DESCRIPTION
Previously, when the current page's path included a 404, the breadcrumbs would stop being created after that.
The "before" page won't show any breadcrumbs other than "home" because "site" doesn't have a page.
TODO: https://github.com/aemsites/learninga-z/issues/140  Find a way to prevent the invalid pages (like /site) from logging a 404 in the browser console and refactor. 

Fix #134 

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.page/site/resources/breakroom-blog/authors/courtney-lofgren
- After: https://134-breadcrumbbug--learninga-z--aemsites.hlx.live/site/resources/breakroom-blog/authors/courtney-lofgren

- Before: https://main--learninga-z--aemsites.hlx.page/site/resources/research-and-efficacy/china-spring-isd
- After: https://134-breadcrumbbug--learninga-z--aemsites.hlx.page/site/resources/research-and-efficacy/china-spring-isd

Testing criteria - what should the reviewer look for in your PR:
The After pages should be showing a complete breadcrumb.

