### PR TITLE
2 column template refactor

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -531,7 +531,7 @@ body.laz-blue {
   }
 
   h3, a {
-    color: var(--laz-blue);
+    color: var(--royal-blue);
   }
 
   h2 {

--- a/templates/blog-article/blog-article.css
+++ b/templates/blog-article/blog-article.css
@@ -50,27 +50,28 @@
     .blog-article main {
         display: grid;
         grid-template-areas:
-        "breadcrumb breadcrumb"
-        "content sidebar"
-    "content sidebar";
+        "breadcrumb breadcrumb breadcrumb breadcrumb"
+        ". content sidebar ."
+         ". content sidebar .";
+        grid-template-columns: 1fr 660px minmax(0, 280px) 1fr;
         column-gap: 40px;
         position: relative;
         max-width: unset;
 
-        .section-outer:not(last-of-type) {
-            grid-area: auto / content;
-            max-width: 660px;
-            justify-self: end;
-            grid-template-rows: max-content;
-        }
+        .section-outer {
+            > .section {
+                padding: 0;
+            }
 
-        .section-outer:last-of-type {
-            grid-area: sidebar;
-            justify-self: start;
-            grid-row-end: last-line;
+            &:not(last-of-type) {
+                grid-area: auto / content;
+                display: grid;
+                grid-template-rows: max-content;
+            }
 
-            .section {
-                width: 240px;
+            &:last-of-type {
+                grid-area: sidebar;
+                grid-row-end: last-line;
             }
         }
     }
@@ -78,13 +79,16 @@
 
 @media (width >= 1200px) {
     .blog-article main {
-        .section-outer:not(last-of-type) {
-            max-width: 800px;
-        }
+        grid-template-columns: 1fr minmax(0, 800px) 300px 1fr;
 
-        .section-outer:last-of-type .section {
-            width: 320px;
-            margin-top: 80px;
+        .section-outer:not(last-of-type) {
+            margin-left: auto;
         }
+    }
+}
+
+@media (width >= 1660px) {
+    .blog-article main {
+        column-gap: 60px;
     }
 }

--- a/templates/research-detail/research-detail.css
+++ b/templates/research-detail/research-detail.css
@@ -1,4 +1,8 @@
 .research-detail main {
+    h1 {
+        font-size: var(--heading-font-size-xl);
+    }
+
     .section-outer {
         margin: unset;
 
@@ -25,10 +29,16 @@
 }
 
 @media (width >= 768px) {
-    .research-detail main .section-outer .section {
-        max-width: 750px;
-        margin-left: auto;
-        margin-right: auto;
+    .research-detail main {
+        h1 {
+            font-size: var(--heading-font-size-xxl);
+        }
+
+        .section-outer .section {
+            max-width: 800px;
+            margin-left: auto;
+            margin-right: auto;
+        }
     }
 }
 
@@ -36,40 +46,46 @@
     .research-detail main {
         display: grid;
         grid-template-areas:
-        "breadcrumb breadcrumb"
-        "content sidebar"
-    "content sidebar";
+        "breadcrumb breadcrumb breadcrumb breadcrumb"
+        ". content sidebar ."
+         ". content sidebar .";
+        grid-template-columns: 1fr 660px minmax(0, 280px) 1fr;
         column-gap: 40px;
         position: relative;
         max-width: unset;
 
-        .section-outer:not(last-of-type) {
-            grid-area: auto / content;
-            max-width: 610px;
-            justify-self: end;
-            grid-template-rows: max-content;
-        }
+        .section-outer {
+            > .section {
+                padding: 0;
+            }
 
-        .section-outer:last-of-type {
-            grid-area: sidebar;
-            justify-self: start;
-            grid-row-end: last-line;
+            &:not(last-of-type) {
+                grid-area: auto / content;
+                display: grid;
+                grid-template-rows: max-content;
+            }
 
-            .section {
-                width: 320px;
+            &:last-of-type {
+                grid-area: sidebar;
+                grid-row-end: last-line;
             }
         }
+
     }
 }
 
 @media (width >= 1200px) {
     .research-detail main {
-        .section-outer:not(last-of-type) {
-            max-width: 760px;
-        }
+        grid-template-columns: 1fr minmax(0, 800px) 300px 1fr;
 
-        .section-outer:last-of-type .section {
-            width: 400px;
+        .section-outer:not(last-of-type) {
+            margin-left: auto;
         }
+    }
+}
+
+@media (width >= 1660px) {
+    .research-detail main {
+        column-gap: 60px;
     }
 }

--- a/templates/video-detail/video-detail.css
+++ b/templates/video-detail/video-detail.css
@@ -1,6 +1,6 @@
 .video-detail main {
     h1 {
-        font-size: var(--heading-font-size-l);
+        font-size: var(--heading-font-size-xl);
     }
 
     .section-outer {
@@ -76,6 +76,10 @@
 
 @media (width >= 768px) {
     .video-detail main {
+        h1 {
+            font-size: var(--heading-font-size-xxl);
+        }
+
         .section-outer .section {
             max-width: 800px;
             margin-left: auto;
@@ -120,7 +124,6 @@
         grid-template-columns: 1fr minmax(0, 800px) 300px 1fr;
 
         .section-outer:not(last-of-type) {
-            /* max-width: 800px; */
             margin-left: auto;
         }
     }


### PR DESCRIPTION
these 2 column templates should look more alike than their live counterparts, this is desired per Sydney to standardize their design.
Also I changed the blog templates' blue link color so it would be more likely to pass accessibility tests.

Fix #170 

Test URLs:
Video template
- Before: https://main--learninga-z--aemsites.hlx.page/site/resources/videos/walmart-grant
- After: https://170-2coltemplate--learninga-z--aemsites.hlx.page/site/resources/videos/walmart-grant

Research template
- Before: https://main--learninga-z--aemsites.hlx.page/site/resources/research-and-efficacy/razplus-milwaukee-study
- After: https://170-2coltemplate--learninga-z--aemsites.hlx.page/site/resources/research-and-efficacy/razplus-milwaukee-study
- 
Blog template
- Before: https://main--learninga-z--aemsites.hlx.page/site/resources/breakroom-blog/fluency-passages
- After: https://170-2coltemplate--learninga-z--aemsites.hlx.page/site/resources/breakroom-blog/fluency-passages


Testing criteria - what should the reviewer look for in your PR:

