### PR TITLE
Table header themes

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -514,6 +514,10 @@ body.purple {
   a {
     color: var(--royal-blue);
   }
+
+  .table table th {
+    background-color: var(--purple);
+    }
 }
 
 [data-theme="purple"] {
@@ -541,6 +545,10 @@ body.laz-blue {
   h2 {
     color: var(--royal-blue);
   }
+
+  .table table th {
+    background-color: var(--laz-blue);
+    }
 }
 
 [data-theme="laz-blue"] {
@@ -578,6 +586,10 @@ body.red {
   a {
     color: var(--red);
   }
+
+  .table table th {
+    background-color: var(--red);
+    }
 }
 
 [data-theme="red"] {
@@ -597,6 +609,10 @@ body.yellow {
   .breadcrumbs-outer {
     background-color: var(--yellow);
   }
+
+  .table table th {
+    background-color: var(--yellow);
+    }
 }
 
   [data-theme="yellow"] {


### PR DESCRIPTION
Fix #180 

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.page/drafts/silviu/table
- After: https://180--learninga-z--aemsites.hlx.page/drafts/silviu/table

I changed the theme of the demo page to purple, see how the new page has the table header purple, just as the breadcrumbs.

