### PR TITLE
222 convert, intercom, json-ld scripts

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/scripts/aem.js" type="module"></script>
+<script type="text/javascript" src="//cdn-4.convertexperiments.com/v1/js/10047477-10048673.js"></script>
 <script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,6 +1,8 @@
 // add delayed functionality here
 // Google Tag Manager script embed
 
+import { loadScript } from './aem.js';
+
 async function enableGoogleTagManager() {
   const gtmScript = document.createElement('script');
   gtmScript.type = 'text/javascript';
@@ -24,3 +26,27 @@ async function enableGoogleTagManager() {
   document.body.insertAdjacentElement('afterbegin', noscriptElement);
 }
 enableGoogleTagManager();
+
+/**
+ * Writes a script element with the LD JSON struct to the page
+ * @param {HTMLElement} parent
+ * @param {Object} json
+ */
+function addLdJsonScript(parent, json) {
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.innerHTML = json;
+  parent.append(script);
+}
+
+const jsonLdMeta = document.querySelector('meta[name="json-ld"]');
+if (jsonLdMeta) {
+  addLdJsonScript(document.querySelector('head'), jsonLdMeta.content);
+  document.querySelector('meta[name="json-ld"]').remove();
+}
+
+loadScript('https://widget.intercom.io/widget/x8m18b9a', {
+  type: 'text/javascript',
+  charset: 'utf-8',
+  async: true,
+});

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -568,7 +568,6 @@ async function loadLazy(doc) {
   await loadSections(main);
   // const breadcrumb = await breadcrumbs(doc);
   // main.prepend(breadcrumb);
-
   const templateName = getMetadata('template');
   if (templateName) {
     await loadTemplate(doc, templateName);


### PR DESCRIPTION


Fix #222 

Test URLs:

Before: https://main--learninga-z--aemsites.hlx.live/
After: https://210-gtm--learninga-z--aemsites.hlx.live/

A video page example:

Before: https://main--learninga-z--aemsites.hlx.live/site/resources/videos/biliteracy-pershing-park
After: https://210-gtm--learninga-z--aemsites.hlx.live/site/resources/videos/biliteracy-pershing-park
A listing/filter page example:

Before: https://main--learninga-z--aemsites.hlx.live/site/resources/research-and-efficacy
After: https://210-gtm--learninga-z--aemsites.hlx.live/site/resources/research-and-efficacy
A research and a news article page:

Before: https://main--learninga-z--aemsites.hlx.live/site/resources/research-and-efficacy/writing-az-meets-criteria-for-essa-level-iv-evidence
After: https://210-gtm--learninga-z--aemsites.hlx.live/site/resources/research-and-efficacy/writing-az-meets-criteria-for-essa-level-iv-evidence
Before: https://main--learninga-z--aemsites.hlx.live/site/company/news/foundations-a-z-launch
After: https://210-gtm--learninga-z--aemsites.hlx.live/site/company/news/foundations-a-z-launch
PDF viewer page:

Before: https://main--learninga-z--aemsites.hlx.live/site/resources/download-library/raz-plus-sel-meaningful-conversations-one-sheet
After: https://210-gtm--learninga-z--aemsites.hlx.live/site/resources/download-library/raz-plus-sel-meaningful-conversations-one-sheet

Testing criteria - what should the reviewer look for in your PR:
- ld+json should only be added to the home page HEAD
- convert JS is on all pages in the head.html due to needing it available before page rendering (this script modifies DOM contents for A/B testing, like Target)
- intercom JS widget is added via delayed on all pages, but due to our domain not being in the allow-list, there will be browser console errors for now.



