### PR TITLE
adding logo-blue option and orange button

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -166,6 +166,8 @@
   --theme-btn-secondary-txt-hov: var(--white);
   --theme-table-head-txt: var(--white);
   --theme-heading-color: var(--laz-logo-blue);
+  --theme-link-color: var(--laz-logo-blue);
+
 } /* end root */
 
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -592,7 +592,8 @@ THEMES
   --theme-cards-circle-bg: var(--product-berry);
 }
 
-[data-theme="berry"], [data-theme="berry-gradient"] {
+[data-theme="berry"], [data-theme="berry-gradient"],
+[data-theme="gradient-rad-berry"], [data-theme="gradient-lin-berry"] {
   --theme-bg: var(--product-berry);
   --theme-btn-primary-txt: var(--product-berry);
   --theme-btn-secondary-txt-hov: var(--product-berry);
@@ -609,7 +610,7 @@ THEMES
   --theme-btn-secondary-txt-hov: var(--product-red);
 }
 
-[data-theme="red"] {
+[data-theme="red"], [data-theme="gradient-rad-red"], [data-theme="gradient-lin-red"] {
   --theme-bg: var(--product-red);
   --theme-btn-primary-txt: var(--product-red);
   --theme-btn-secondary-txt-hov: var(--product-red);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -913,6 +913,10 @@ THEMES
   color: var(--product-dark-blue);
 }
 
+:is(h1, h2, h3, h4).logo-blue {
+  color: var(--laz-logo-blue);
+}
+
 .bg-berry {
   background-color: var(--product-berry);
 }
@@ -994,6 +998,17 @@ THEMES
     }
   }
 
+  &.bgcolor-orange {
+    background-color: var(--product-orange);
+    border-color: var(--product-orange);
+
+    &:hover {
+      color: var(--product-orange);
+      border-color: var(--product-orange);
+      background-color: var(--theme-btn-primary-bg-hov);
+    }
+  }
+
   &.bgcolor-gold {
     background-color: var(--rpe-gold);
     border-color: var(--rpe-gold);
@@ -1036,6 +1051,17 @@ THEMES
       color: var(--product-navy-blue);
       border-color: var(--product-navy-blue);
       background-color: var(--theme-btn-primary-bg-hov);
+    }
+  }
+
+  &.bgcolor-logo-blue {
+    background-color: var(--laz-logo-blue);
+    border-color: var(--laz-logo-blue);
+
+    &:hover {
+      color: var(--laz-logo-blue);
+      border-color: var(--laz-logo-blue);
+      background-color: var(--white);
     }
   }
 
@@ -1112,6 +1138,17 @@ button.secondary {
     background-color: var(--product-navy-blue);
     color: var(--white);
     border-color: var(--product-navy-blue);
+  }
+}
+
+.button.secondary.textcolor-logo-blue {
+  color: var(--laz-logo-blue);
+  border-color: var(--laz-logo-blue);
+
+  &:hover {
+    background-color: var(--laz-logo-blue);
+    color: var(--white);
+    border-color: var(--laz-logo-blue);
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -694,7 +694,7 @@ THEMES
 
 .orange main {
   --theme-breadcrumbs-bg: var(--product-orange);
-  --theme-heading-color: var(--product-orange);
+  --theme-heading-color: var(--laz-logo-blue);
   --theme-link-color: var(--product-orange);
   --theme-btn-primary-border: var(--product-orange);
   --theme-btn-primary-bg: var(--product-orange);


### PR DESCRIPTION
added "logo-blue" option to headline color overrides.

Fix #329 

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.live/site/lp2/raz-plus-sel
- After: https://329-logoblue--learninga-z--aemsites.hlx.live/site/lp2/raz-plus-sel

Headlines will be blue now.
![image](https://github.com/user-attachments/assets/c6736ceb-a760-44db-879a-c33bc599eaa8)


