### PR TITLE
removed 0 padding

### DIFF
--- a/blocks/download-filter/download-filter.css
+++ b/blocks/download-filter/download-filter.css
@@ -1,6 +1,5 @@
 /* stylelint-disable no-descending-specificity */
 main > .section-outer > .section.download-cards-section {
-    padding: 0;
     max-width: 100%;
 
     .default-content-wrapper {


### PR DESCRIPTION
in mobile, padding=0 was not enough.

Fix #358  #359 

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.live/site/resources/download-library-by-type
- After: https://359-downloadfilter--learninga-z--aemsites.hlx.live/site/resources/download-library-by-type



