### PR TITLE
blog 1 column add, related posts title cleanup

### DIFF
--- a/blocks/related-posts/related-posts.js
+++ b/blocks/related-posts/related-posts.js
@@ -3,8 +3,9 @@ import { createTag, lookupBlogs } from '../../scripts/scripts.js';
 export async function createPageLinks(row, style) {
   const linkPost = document.createElement('div');
   if (style) linkPost.classList.add(style);
-  const title = createTag('div', { class: 'title' });
-  title.innerHTML = `<a href="${row.path}"><h3>${row.title}</h3></a>`;
+  const title = createTag('div', {class: 'title'});
+  title.innerHTML = `<a href="${row.path}"><h3>${row.title.replace(/ \| Learning A-Z$|- Learning A-Z$/, '')}</h3></a>`;
+
   linkPost.append(title);
   return linkPost;
 }

--- a/blocks/related-posts/related-posts.js
+++ b/blocks/related-posts/related-posts.js
@@ -3,7 +3,7 @@ import { createTag, lookupBlogs } from '../../scripts/scripts.js';
 export async function createPageLinks(row, style) {
   const linkPost = document.createElement('div');
   if (style) linkPost.classList.add(style);
-  const title = createTag('div', {class: 'title'});
+  const title = createTag('div', { class: 'title' });
   title.innerHTML = `<a href="${row.path}"><h3>${row.title.replace(/ \| Learning A-Z$|- Learning A-Z$/, '')}</h3></a>`;
 
   linkPost.append(title);

--- a/templates/blog-article/blog-article.css
+++ b/templates/blog-article/blog-article.css
@@ -29,12 +29,22 @@
         }
     }
 
+.blog-article.col-1 main .section-outer .section .default-content-wrapper {
+    text-align: left;
+}
+
 @media (width >= 768px) {
     .blog-article main {
         .section-outer .section {
             max-width: 800px;
             margin-left: auto;
             margin-right: auto;
+        }
+    }
+
+    .blog-article.col-1 main {
+        .section-outer .section {
+            max-width: 1170px;
         }
     }
 }
@@ -71,6 +81,10 @@
                 grid-area: content;
             }
         }
+    }
+
+    .blog-article.col-1 main {
+            display: block;
     }
 }
 


### PR DESCRIPTION

Fix #354 
Test URLs:
this should be 1 column
- Before: https://main--learninga-z--aemsites.hlx.live/site/resources/breakroom-blog/experience-reading-a-z-series
- After: https://345-col1theme--learninga-z--aemsites.hlx.live/site/resources/breakroom-blog/experience-reading-a-z-series

this should be 2 columns
- Before: https://main--learninga-z--aemsites.hlx.live/site/resources/breakroom-blog/why-vocabulary-matters
- After: https://345-col1theme--learninga-z--aemsites.hlx.live/site/resources/breakroom-blog/why-vocabulary-matters

