### PR TITLE
add default logo-blue bg color

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -172,6 +172,7 @@
   --theme-heading-color: var(--laz-logo-blue);
   --theme-link-color: var(--laz-logo-blue);
   --theme-breadcrumbs-bg: var(--laz-logo-blue);
+  --theme-cards-circle-bg: var(--laz-logo-blue);
 
 } /* end root */
 


### PR DESCRIPTION


Fix #387 

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.page/tools/sidekick/library/blocks/cards
- After: https://387-defaultbg--learninga-z--aemsites.hlx.page/tools/sidekick/library/blocks/cards

Circle cards now have the default logo-blue background.
