### PR TITLE
multiple carousels styling

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -263,7 +263,7 @@ export async function renderCardList(wrapper, cards, limit = 9, type = 'card') {
 }
 
 /** function to get an array of card objects from indexData */
-function getCardObject(link) {
+export function getCardObject(link) {
   const path = link?.getAttribute('href');
   const relPath = getRelativePath(path);
   return indexData.find((item) => item.path === relPath);

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -29,35 +29,45 @@
   position: relative;
   user-select: none;
   justify-content: space-between;
-}
 
-.carousel .carousel-slide .carousel-slide-content h2 {
-  font-size: 44px;
-  font-weight: 700 !important;
-}
+  .carousel-slide-content {
+    flex: 0 60%;
+    margin: 40px 0;
+    display: flex;
+    flex-direction: column;
 
-.carousel .carousel-slide .carousel-slide-content p {
-  font-size: var(--body-font-size-m);
-  font-weight: var(--font-weight-medium);
-}
+    p {
+      font-size: var(--body-font-size-m);
+    }
 
-.carousel .carousel-slide .carousel-slide-image picture {
-  position: relative;
-  inset: 0;
-}
+    h1, h2 {
+      font-size: 38px;
+      line-height: 1.1;
+      margin: 0 0 16px;
+    }
+  }
 
-.carousel .carousel-slide .carousel-slide-image picture > img {
-  flex: 0 40%;
-  border-radius: 20px;
-  user-select: none;
-}
+  .carousel-slide-image {
+    picture {
+    /* position: relative; */
+    inset: 0;
+    height: 368px;
+    width: 100%;
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 20px;
 
-.carousel .carousel-slide .carousel-slide-content {
-  flex: 0 60%;
-  margin: 40px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+      img {
+        flex: 0 40%;
+        user-select: none;
+        object-fit: cover;
+        height: 100%;
+        width: 100%;
+      }
+    }
+  }
 }
 
 .carousel .carousel-slide-indicators {
@@ -70,8 +80,8 @@
 }
 
 .carousel .carousel-slide-indicator button {
-  width: 12px;
-  height: 12px;
+  width: 13px;
+  height: 13px;
   margin: 0;
   padding: 0;
   border-radius: 50%;
@@ -91,6 +101,7 @@
   display: flex;
   z-index: 1;
   justify-content: space-between;
+  top: -30px;
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
@@ -153,56 +164,231 @@
   }
 }
 
-.carousel.vertical {
+.carousel.cards {
   .carousel-slides-container {
     padding: 20px 0;
   }
 
   .carousel-slide {
-    flex: 0 0 32%;
-    border: 2px solid #D8D8D9;
+    border: 2px solid var(--gray);
+    background: var(--gray);
     margin: 0 10px;
     justify-content: space-between;
 
-    .carousel-slide-image picture > img {
+    .button-container {
+      margin: 0;
+
+      a.button.secondary {
+        display: none;
+      }
+    }
+
+    .carousel-slide-image picture {
+     height: 13em;
       border-radius: 0;
+
+      > img {
+        height: auto;
+      }
     }
 
     .carousel-slide-content {
-      margin: 0 20px;
-    }
+      margin: 24px;
 
-    .button-container {
-     margin: 0 auto;
+      h3 {
+        line-height: unset;
+      }
+    }
+  }
+
+  i.arrow {
+    background-color: var(--light-gray);
+    padding: 10px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 40px;
+    height: 40px;
+    text-align: center;
+
+    img { /* stylelint-disable-line no-descending-specificity */
+      width: 16px;
+      height: 16px;
+      object-fit: contain;
+      filter: brightness(10%) invert(1);
     }
   }
 }
 
-@media (width >= 1296px) {
-  .carousel:not(.vertical) .carousel-slide {
-    flex-direction: row;
-    padding-left: 80px;
-    padding-right: 80px;
+.carousel.tall {
+  .carousel-slide {
+    background: white;
+
+    .carousel-slide-content {
+      margin: 50px 32px 32px;
+
+      h3 {
+        font-size: 1.4em;
+        color: var(--text-color);
+        font-weight: var(--font-weight-bold);
+        line-height: 1.4;
+      }
     }
 
-    .carousel .carousel-slide .carousel-slide-content h2 {
-      font-size: 30px;
-      font-weight: 700 !important;
+    .button-container {
+      a.button.secondary {
+        display: inline;
+        color: unset;
+        border: 0;
+        background-color: unset;
+        font-weight: 400;
+        text-decoration: underline;
+        padding: 0;
+      }
     }
+  }
 
-    .carousel .carousel-slide .carousel-slide-content {
-      align-items: start;
-    }
-
-    .carousel .carousel-navigation-buttons {
-      transform: translateY(-500%);
-    }
-
-    .carousel .carousel-navigation-buttons button.slide-next {
-      right: -80px
-    }
-
-    .carousel .carousel-navigation-buttons button.slide-prev {
-      left: -80px
-    }
+  .arrow { display: none; }
 }
+
+@media (width >= 768px) {
+  .carousel:not(.cards) {
+    .carousel-slide-image picture img {
+      height: unset;
+    }
+  }
+
+  .carousel.cards {
+    .carousel-slide {
+      flex: 0 0 48%;
+
+       .carousel-slide-image picture {
+         > img {
+           height: 100%;
+         }
+       }
+    }
+  }
+}
+
+@media (width >= 1024px) {
+  .carousel.featured {
+    .carousel-slide {
+      flex-direction: row;
+      gap: 66px;
+
+      .carousel-slide-content {
+        align-items: start;
+
+      }
+
+      .carousel-slide-image {
+        width: 55%;
+
+          picture {
+            height: unset;
+          }
+      }
+    }
+  }
+
+  .carousel.cards {
+    .carousel-slides-container {
+      width: 780px;
+      margin: auto;
+    }
+  }
+}
+
+@media (width >= 1200px) {
+  .carousel.cards {
+    .carousel-slides-container {
+      width: 980px;
+      margin: auto;
+    }
+
+    .carousel-slide {
+      flex: 0 0 32%;
+    }
+  }
+
+  .carousel:not(.cards) {
+    .carousel-slide {
+      flex-direction: row;
+      gap: 66px;
+      padding-left: 80px;
+      padding-right: 80px;
+
+      .carousel-slide-content {
+        align-items: start;
+      }
+
+      .carousel-slide-image {
+        width: 55%;
+
+        picture {
+          height: 23em;
+
+          img {
+            height: 100%;
+          }
+        }
+      }
+    }
+  }
+
+  .carousel:not(.featured) {
+    .carousel-navigation-buttons {
+      transform: translateY(-400%);
+
+      button.slide-next {
+        right: -5px
+      }
+
+      button.slide-prev {
+        left: -5px
+      }
+    }
+  }
+
+  .carousel.featured {
+    .carousel-slide {
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    .carousel-slide .carousel-slide-image {
+      width: 65%;
+
+      picture {
+        height: 100%;
+      }
+    }
+  }
+}
+
+@media (width >= 1600px) {
+  .carousel:not(.cards) {
+    .carousel-slide {
+        padding-left: 0;
+        padding-right: 0;
+    }
+  }
+
+  .carousel, .carousel:not(.featured) {
+    .carousel-slides-container {
+      width: unset;
+    }
+
+    .carousel-navigation-buttons {
+      button.slide-next {
+        right: -80px
+      }
+
+      button.slide-prev {
+        left: -80px
+      }
+    }
+  }
+}
+

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -120,7 +120,7 @@ let carouselId = 0;
 export default async function decorate(block) {
   carouselId += 1;
   block.setAttribute('id', `carousel-${carouselId}`);
-  const linkedCarousel = block.classList.contains('card-links');
+  const linkedCarousel = block.classList.contains('cards') || block.classList.contains('links');
   const rows = block.querySelectorAll(':scope > div');
   let isSingleSlide = false;
   if (linkedCarousel) {
@@ -163,7 +163,7 @@ export default async function decorate(block) {
     block.append(slideNavButtons);
   }
 
-  if (block.classList.contains('card-links')) {
+  if (block.classList.contains('links') || block.classList.contains('cards')) {
     const rows1 = [];
     const cardLinks = block.querySelectorAll('a');
     const indexData = await getGenericIndexData();
@@ -175,18 +175,21 @@ export default async function decorate(block) {
         const col2 = document.createElement('div');
         col2.innerHTML = '';
         if (card.image) {
-          col1.innerHTML = createOptimizedPicture(card.image, card.title).outerHTML;
+          col1.innerHTML = createOptimizedPicture(card.image, card.title, false).outerHTML;
         }
-        if (block.classList.contains('featured')) {
-          col2.innerHTML = '<p> <strong>FEATURED</strong></p>';
-        }
-        if (card.title) {
-          col2.innerHTML += `<h2>${card.title}</h2>`;
+        if (card.title && block.classList.contains('featured')) {
+          col2.innerHTML += `<p> <strong>FEATURED</strong></p>
+               <a href="${card.path}"><h1>${card.title.replace(/ \| Learning A-Z$|- Learning A-Z$/, '')}</h1></a>`;
+        } else if (card.title) {
+          col2.innerHTML += `<a href="${card.path}"><h3>${card.title.replace(/ \| Learning A-Z$|- Learning A-Z$/, '')}</h3></a>`;
         }
         if (card.description) {
-          col2.innerHTML += `<p>${card.description}</p>`;
+          col2.innerHTML += `<p>${card.description}</p><p><em><a href="${card.path}">Learn More</a></em></p>`;
         }
-        col2.innerHTML += `<p><em><a href="${card.path}">Learn More</a></em></p>`;
+        if (block.classList.contains('cards')) {
+          col2.innerHTML += `<a href="${card.path}"><i class="arrow"><img alt="arrow" src="/icons/solutions-right.svg"></i></a>`;
+        }
+
         if (col1.innerHTML || col2.innerHTML) {
           row.append(col1);
           row.append(col2);
@@ -194,6 +197,7 @@ export default async function decorate(block) {
         }
       }
     });
+
     buildSlides(rows1, slideIndicators, carouselId, placeholders, slidesWrapper);
     block.querySelector(':scope > div').remove();
   } else {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -253,13 +253,13 @@ h3, h4, h5, h6 {
 
 h1 {
   font-size: var(--heading-font-size-xl);
-  margin: 50px 0 1em;
+  margin: 20px 0 1em;
   line-height: 1.2;
 }
 
 h2 {
   font-size: var(--heading-font-size-s);
-  margin-bottom: 1em;
+  margin: 20px 0 1em;
   line-height: 1.35;
 }
 

--- a/templates/wide/wide.css
+++ b/templates/wide/wide.css
@@ -105,6 +105,15 @@
 
         .carousel-slide-image {
             width: 10%;
+
+            picture {
+                height: unset;
+
+                > img {
+                    object-fit: unset;
+                    height: unset;
+                }
+            }
         }
     }
 
@@ -112,6 +121,7 @@
         margin-top: -80px;
         padding-left: 10px;
         padding-right: 10px;
+        top: 0;
     }
 }
 


### PR DESCRIPTION


Fix #15 

Test URLs:
Library page:
- Before: https://main--learninga-z--aemsites.hlx.live/tools/sidekick/library/blocks/carousel
- After: https://15-rseourcescarousel--learninga-z--aemsites.hlx.page/tools/sidekick/library/blocks/carousel

carousel (links, featured)
- Before: https://main--learninga-z--aemsites.hlx.live/site/resources/breakroom-blog
- After: https://15-rseourcescarousel--learninga-z--aemsites.hlx.page/site/resources/breakroom-blog

carousel (cards) and carousel (cards, tall)
- Before: https://main--learninga-z--aemsites.hlx.live/site/resources
- After: https://15-resourcescarousel--learninga-z--aemsites.hlx.live/site/resources

carousel (look at the one after the yellow section)
- Before: https://main--learninga-z--aemsites.hlx.live
- After: https://15-resourcescarousel--learninga-z--aemsites.hlx.live

Compare with the customer live pages.

