### PR TITLE
putting flex back

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -62,9 +62,7 @@
     height: 368px;
     width: 100%;
       overflow: hidden;
-
-   /*   display: flex; */
-
+      display: flex;
       align-items: center;
       justify-content: center;
       border-radius: 20px;


### PR DESCRIPTION
carousel image sizing fix

Fix #

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.live/
- After: https://golive--learninga-z--aemsites.hlx.live/

Testing criteria - what should the reviewer look for in your PR:
Should look like this in FF and Chrome
![image](https://github.com/user-attachments/assets/f965424d-0aa1-481d-a34c-9d50793740a6)


