### PR TITLE
moved the grid template to the right place

### DIFF
--- a/templates/wide/wide.css
+++ b/templates/wide/wide.css
@@ -187,9 +187,6 @@
     main > .section-outer:nth-child(2) .section {
         max-width: 1527px;
         margin: 0 auto;
-    }
-
-    .wide .section.product {
         grid-template-columns: 55% auto;
     }
 }


### PR DESCRIPTION


Fix #509 

Test URLs:
- Before: https://main--learninga-z--aemsites.hlx.live/site/products/raz-plus/overview
- After: https://509-productcta--learninga-z--aemsites.hlx.live/site/products/raz-plus/overview

Testing criteria - what should the reviewer look for in your PR:

The last product section should not be too skinny -- this is bad
![image](https://github.com/user-attachments/assets/a97a24a2-d28b-4792-a632-eb945edd73c3)

