### PR TITLE
"signs" positioning fix in stacked columns

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -14,7 +14,6 @@
 .columns.stacked {
   display: grid;
   grid-template-columns: 1fr;
-  min-height: 300px;
 
   &.gray {
     background: var(--gray);

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -14,6 +14,7 @@
 .columns.stacked {
   display: grid;
   grid-template-columns: 1fr;
+  min-height: 300px;
 
   &.gray {
     background: var(--gray);
@@ -300,9 +301,10 @@
   }
 
   .columns.signs > div:last-child picture:last-child {
+    text-align: center;
     position: relative;
     right: -54%;
-    top: -450%;
+    bottom: 350%;
   }
 
   .columns.wrap > div > div {


### PR DESCRIPTION
Had to adjust the signs position so they looked ok in both short columns and long ones.

Fix #406 

Test URLs:
The 3 stacked columns with equals and plus signs should look better now:
- Before: https://main--learninga-z--aemsites.hlx.live/site/lp2/foundations-a-z-raz-plus-powerful-duo
- After: https://post-launch--learninga-z--aemsites.hlx.live/site/lp2/foundations-a-z-raz-plus-powerful-duo

THe signs are a little lower but still look OK
- Before: https://main--learninga-z--aemsites.hlx.live/site/products/raz-kids/overview
- After: https://post-launch--learninga-z--aemsites.hlx.live/site/products/raz-kids/overview


