### PR TITLE
adding section style=banner

### DIFF
--- a/templates/blog-article/blog-article.css
+++ b/templates/blog-article/blog-article.css
@@ -41,6 +41,11 @@ h1 {
             }
         }
 
+    .section-outer:has(.section.banner) {
+        padding-top:16px;
+        padding-bottom: 16px;
+    }
+
         .blog-heading h1{
             margin-bottom: 0;
         }
@@ -67,6 +72,10 @@ h1 {
 }
 
 @media (width >= 1024px) {
+    .breadcrumbs-outer {
+        grid-area: breadcrumb;
+    }
+
     .blog-article main {
         display: grid;
         grid-template-areas:
@@ -98,6 +107,11 @@ h1 {
             &:first-of-type {
                 grid-area: content;
             }
+        }
+
+        .section-outer:has(.section.banner) {
+            grid-area: breadcrumb;
+            margin-top:50px;
         }
     }
 


### PR DESCRIPTION
When a section with style="banner" is created on a blog-article page, that section will be added to the breadcrumb area.

Fix #528 

Test URLs:
- Before: https://main--learninga-z--aemsites.aem.page/site/resources/breakroom-blog/best-phonics-games-for-kindergarten-and-early-elementary-students
- After: https://528-linkunderlines--learninga-z--aemsites.aem.page/site/resources/breakroom-blog/best-phonics-games-for-kindergarten-and-early-elementary-students



